### PR TITLE
Fixed MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,8 @@
 include tox.ini
 include README.rst
 include LICENSE.txt
+include zengin_code/source-data/data/md5
+include zengin_code/source-data/data/updated_at
+include zengin_code/source-data/data/*.json
+include zengin_code/source-data/data/branches/*.json
 recursive-include tests *.py

--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ Usage
 Contributing
 ===============
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/zengin_code/zengin-py
+Bug reports and pull requests are welcome on GitHub at https://github.com/zengin-code/zengin-py
 
 License
 ===============


### PR DESCRIPTION
@rosylilly

Sorry. I had mistaken how writing "MANIFEST.in".
Data files were not included in the "sdist(Source Distribution)".

I've removed the "sdist" only on pypi in haste.
You have only to merge this PR.
From the next it will be correctly "sdist" upload.

Thanks
