### PR TITLE
Always try to read the data files as UTF-8.

### DIFF
--- a/zengin_code/__init__.py
+++ b/zengin_code/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import division, print_function, absolute_import  # NOQA
 
+import six
 import json
 import os
 
@@ -14,8 +15,9 @@ def _load(*path):
     ret = None
     here = os.path.dirname(__file__)
     data_dir = os.path.join(here, 'source-data', 'data')
-    with open(os.path.join(data_dir, *path), 'r') as fp:
+    with open(os.path.join(data_dir, *path), 'rb') as fp:
         ret = fp.read()
+    ret = six.text_type(ret, 'utf-8')
     return ret
 
 


### PR DESCRIPTION
このプロジェクトのJSONのデータファイルは常に UTF-8 でエンコードされていますが、普通にテキストモードで `open()` した場合、ファイルのエンコーディングはロカール (`LC_CTYPE` 環境変数など) で指定された想定で読み込まれます。したがって、適切なロケールの設定がされていないと、モジュールの読み込みに失敗してしまいます。

このパッチは、ファイルをバイナリモードで `open()` し、読み込んだバイナリを UTF-8 としてデコードしたものを `_load()` で返すようにしたものです。

