### PR TITLE
Fixed .pypirc in ci/deploy

### DIFF
--- a/bin/ci/deploy
+++ b/bin/ci/deploy
@@ -8,12 +8,7 @@ git config user.name "zeny-man"
 CI_RELEASE_VERSION=`date +"v%Y-%m-%d"`
 
 cat > $HOME/.pypirc << EOF
-[distutils]
-index-servers=
-    pypi
-
 [pypi]
-repository = https://pypi.python.org/pypi
 username = ${PYPI_USERNAME}
 password = ${PYPI_PASSWORD}
 EOF


### PR DESCRIPTION
@rosylilly  

I found that the latest version(`20171111`) has not been uploaded to `pypi`.
The last uploaded version was `20170608` .

https://pypi.python.org/pypi/zengin_code/1.1.0.20170608

I investigated about it.
I found that there was a change in .pypirc.

https://packaging.python.org/guides/migrating-to-pypi-org/
https://packaging.python.org/tutorials/distributing-packages/#uploading-your-project-to-pypi

I modified it according to the above URL. 
I think that the next will be successfully uploaded.

Please feel free to merge it. thx :)