### PR TITLE
Fix failed tests.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,3 +9,7 @@ strict = 1
 
 [aliases]
 release = sdist bdist_wheel 
+test=pytest
+
+[tool:pytest]
+addopts = --verbose --cov zengin_code tests --cov-report term-missing

--- a/setup.py
+++ b/setup.py
@@ -5,26 +5,7 @@ import os
 import re
 
 from setuptools import setup, find_packages
-from setuptools.command.test import test as TestCommand
 
-
-class PyTest(TestCommand):
-    user_options = [('pytest-args=', 'a', 'Arguments to pass to py.test')]
-
-    def initialize_options(self):
-        TestCommand.initialize_options(self)
-        self.pytest_args = []
-
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        # import here, cause outside the eggs aren't loaded
-        import pytest
-        errno = pytest.main(self.pytest_args)
-        sys.exit(errno)
 
 here = os.path.dirname(__file__)
 package_path = os.path.join(here, 'zengin_code')
@@ -44,9 +25,13 @@ requires = [
     'six',
 ]
 
+setup_requires = [
+   'pytest-runner',
+]
+
 tests_require = [
-    'pytest-cov',
-    'pytest',
+   'pytest-cov',
+   'pytest',
 ]
 
 classifiers = [
@@ -56,9 +41,10 @@ classifiers = [
     'Programming Language :: Python :: 2',
     'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.3',
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
+    'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: Implementation :: CPython',
     'Programming Language :: Python :: Implementation :: PyPy',
     'Topic :: Internet :: WWW/HTTP',
@@ -77,8 +63,8 @@ setup(
     classifiers=classifiers,
     keywords=['zengin', 'bank', 'japanese'],
     install_requires=requires,
+    setup_requires=setup_requires,
     tests_require=tests_require,
-    cmdclass={'test': PyTest},
     packages=find_packages(exclude=['tests']),
     include_package_data=True,
     package_data={

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-envlist=py27,py34,py35,py36,pypy,flake8
+envlist=py27,py34,py35,py36,py37,flake8
 skipsdist=True
 
 [testenv]
 commands=
-    python setup.py test -a "--cov zengin_code tests --cov-report term-missing"
+    python setup.py test
 
 [testenv:flake8]
 deps=flake8


### PR DESCRIPTION
Hi @rosylilly 

I noticed that the test failed, so I fixed it.
https://circleci.com/gh/zengin-code/zengin-py/217

It seems that the integration way of pytest and setup.py has become obsolete.

Updated according to the latest integration way.
https://docs.pytest.org/en/latest/goodpractices.html#integrating-with-setuptools-python-setup-py-test-pytest-runner

Please feel free to merge it. 
Thx